### PR TITLE
Add Blinding Key of the LBTC confidential input used to make a full confidential transaction

### DIFF
--- a/taxi.proto
+++ b/taxi.proto
@@ -22,6 +22,7 @@ message TopupWithAssetRequest {
 message TopupWithAssetReply {
   Topup topup = 1;
   uint64 expiry = 2; // the unix timestamp after wich the locked LBTC input will provably be double-spent
+  string blinding_key = 3; // the hex encoded blinding private key of the locked LBTC input
 }
 
 message Topup {


### PR DESCRIPTION
Before this we assume the LBTC input and USDT payout output to be unconfidential. This could undermine the privacy and kind of fingerprint the transactions that use Taxi.