### PR TITLE
add public_blinding_key member in TopupWithAssetReply

### DIFF
--- a/taxi.proto
+++ b/taxi.proto
@@ -22,7 +22,8 @@ message TopupWithAssetRequest {
 message TopupWithAssetReply {
   Topup topup = 1;
   uint64 expiry = 2; // the unix timestamp after wich the locked LBTC input will provably be double-spent
-  string blinding_key = 3; // the hex encoded blinding private key of the locked LBTC input
+  string private_blinding_key = 3; // the hex encoded blinding private key of the locked LBTC input
+  string public_blinding_key = 4; // the hex encoded blinding public key of the pay to taxi output
 }
 
 message Topup {


### PR DESCRIPTION
We decided to return the input's blinding private key to let the user blind the transaction. In this case, (the user blinds all the outputs), he will need the **public blinding key** of the taxi output.

@tiero @altafan please review