### PR TITLE
Topup with known payout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.17
-        id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
       - name: Setup build.buf
         uses: bufbuild/buf-setup-action@v1.1.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,5 @@ jobs:
         with:
           version: 1.1.0
 
-      - name: Generate stubs
+      - name: Lint protos
         run: make proto-lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        
       - name: Setup build.buf
         uses: bufbuild/buf-setup-action@v1.1.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           version: 1.1.0
 
-      - name: Generate stubs
+      - name: Lint protos
         run: make proto-lint
 
       - uses: bufbuild/buf-push-action@v1        

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,17 +9,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.17
-        id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-        with:
-          ref: v1
-
       - name: Setup build.buf
         uses: bufbuild/buf-setup-action@v1.1.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
       - name: Setup build.buf
         uses: bufbuild/buf-setup-action@v1.1.0
         with:

--- a/api-spec/protobuf/taxi/v1/taxi.proto
+++ b/api-spec/protobuf/taxi/v1/taxi.proto
@@ -51,13 +51,17 @@ message TopupWithKnownPayoutRequest {
   uint64 millisat_per_byte = 2; // how many millisatoshi per byte we want to spend
 }
 message TopupWithKnownPayoutResponse {
-  Topup topup = 1; // the Topup message 
+  TopupInfo topup = 1;
   uint64 expiry = 2; // the unix timestamp after wich the locked LBTC input will be double-spent
 }
 
+message TopupInfo {
+  string topup_id = 1;
+  string partial = 2;
+}
+
 message Topup {
-  string topup_id = 1; // random identifier of the current topup
-  string partial = 2; // PSET signed with SIGHASH_SINGLE | ANYONECANPAY
+  TopupInfo info = 1;
   string asset_hash = 3; // the asset hash used as payout for bitcoin fees
   uint64 asset_amount = 4; // the asset denominated amount expressed in satoshis to be used as payout. It includes also the spread as taxi service fee
   uint64 asset_spread = 5; // the spread amount expressed in asset denominated satoshis used to pay the taxi service fees

--- a/api-spec/protobuf/taxi/v1/taxi.proto
+++ b/api-spec/protobuf/taxi/v1/taxi.proto
@@ -20,6 +20,15 @@ service TaxiService {
       body: "*"
     };
   }
+
+  // TopupWithKnownPayout adds ins and outs to the given transaction if this contains at least one
+  // known payout, ie. one output with a "whitelisted" script.
+  rpc TopupWithKnownPayout(TopupWithKnownPayoutRequest) returns (TopupWithKnownPayoutResponse) {
+    option (google.api.http) = {
+      post: "/v1/payout/topup"
+      body: "*"
+    };
+  }
 }
 
 message ListAssetsRequest {}
@@ -33,10 +42,17 @@ message TopupWithAssetRequest {
   uint64 millisat_per_byte = 3; // how many millisatoshi per byte we want to spend. ie. 0.1 sat/byte = 100 mSats/byte
 }
 message TopupWithAssetResponse {
-  Topup topup = 1; // The Topup message 
-  uint64 expiry = 2; // the unix timestamp after wich the locked LBTC input will provably be double-spent
-  string private_blinding_key = 3; // the hex encoded blinding private key of the locked LBTC input
-  string public_blinding_key = 4; // the hex encoded blinding public key of the pay to taxi output
+  Topup topup = 1; // the Topup message 
+  uint64 expiry = 2; // the unix timestamp of the topup expiration date. After that date, the taxi sends the locked utxos to itself to prevent being spent by others
+}
+
+message TopupWithKnownPayoutRequest {
+  string partial = 1; // transaction in base64 format including the known payout
+  uint64 millisat_per_byte = 2; // ow many millisatoshi per byte we want to spend
+}
+message TopupWithKnownPayoutResponse {
+  Topup topup = 1; // the Topup message 
+  uint64 expiry = 2; // the unix timestamp after wich the locked LBTC input will be double-spent
 }
 
 message Topup {

--- a/api-spec/protobuf/taxi/v1/taxi.proto
+++ b/api-spec/protobuf/taxi/v1/taxi.proto
@@ -44,6 +44,9 @@ message TopupWithAssetRequest {
 message TopupWithAssetResponse {
   Topup topup = 1; // the Topup message 
   uint64 expiry = 2; // the unix timestamp of the topup expiration date. After that date, the taxi sends the locked utxos to itself to prevent being spent by others
+  string asset_hash = 3; // the asset hash used as payout for bitcoin fees
+  uint64 asset_amount = 4; // the asset denominated amount expressed in satoshis to be used as payout. It includes also the spread as taxi service fee
+  uint64 asset_spread = 5; // the spread amount expressed in asset denominated satoshis used to pay the taxi service fees
 }
 
 message TopupWithKnownPayoutRequest {
@@ -51,20 +54,13 @@ message TopupWithKnownPayoutRequest {
   uint64 millisat_per_byte = 2; // how many millisatoshi per byte we want to spend
 }
 message TopupWithKnownPayoutResponse {
-  TopupInfo topup = 1;
+  Topup topup = 1;
   uint64 expiry = 2; // the unix timestamp after wich the locked LBTC input will be double-spent
 }
 
-message TopupInfo {
+message Topup {
   string topup_id = 1;
   string partial = 2;
-}
-
-message Topup {
-  TopupInfo info = 1;
-  string asset_hash = 3; // the asset hash used as payout for bitcoin fees
-  uint64 asset_amount = 4; // the asset denominated amount expressed in satoshis to be used as payout. It includes also the spread as taxi service fee
-  uint64 asset_spread = 5; // the spread amount expressed in asset denominated satoshis used to pay the taxi service fees
 }
 
 message AssetDetails {

--- a/api-spec/protobuf/taxi/v1/taxi.proto
+++ b/api-spec/protobuf/taxi/v1/taxi.proto
@@ -48,7 +48,7 @@ message TopupWithAssetResponse {
 
 message TopupWithKnownPayoutRequest {
   string partial = 1; // transaction in base64 format including the known payout
-  uint64 millisat_per_byte = 2; // ow many millisatoshi per byte we want to spend
+  uint64 millisat_per_byte = 2; // how many millisatoshi per byte we want to spend
 }
 message TopupWithKnownPayoutResponse {
   Topup topup = 1; // the Topup message 


### PR DESCRIPTION
This references to [#92](https://github.com/vulpemventures/taxi-daemon/issues/92) and adds and RPC to TaxiService to let one have his partial tx funded with LBTC by the taxi (covering the network fees) in case the tx contains one or more "whitlisted" payout.

Please @tiero review this.